### PR TITLE
Unrelated method implements IReadOnly interface

### DIFF
--- a/Implementations/KeyedCollection.cs
+++ b/Implementations/KeyedCollection.cs
@@ -25,7 +25,12 @@ public class MyKeyedCollection : IMyDictionary<string, string>, IMyList<string>
 
     public ICollection<string> Values => _dictionary.Values;
 
-    public int Count => _dictionary.Count;
+    int IMyCollection<string>.Count => _list.Count;
+    int IMyCollection<KeyValuePair<string, string>>.Count => _dictionary.Count;
+
+    // No connection to the implemented collection interfaces, but ends up
+    // implementing the IReadOnlyCollection interfaces for both
+    public virtual int Count => throw new NotImplementedException();
 
     public bool IsReadOnly => false;
 


### PR DESCRIPTION
Because default interface methods are considered lower priority than the "old" interface resolution algorithm, a suitable public virtual method with the same name/sig will implement the interface method.

If this diff is applied, Application will throw a `NotImplementedException` because the default implementation was ignored in favor of a pre-existing (but unrelated) name/sig match.