### PR TITLE
Add new Contains method to IMySet<T> to prevent source breaking change

### DIFF
--- a/Interfaces/Net80.cs
+++ b/Interfaces/Net80.cs
@@ -103,6 +103,7 @@ public interface IMySet<T> : IMyCollection<T>, IMyReadOnlySet<T>
     new bool IsProperSubsetOf(IEnumerable<T> other);
     new bool Overlaps(IEnumerable<T> other);
     new bool SetEquals(IEnumerable<T> other);
+    new bool Contains(T value) => ((IMyCollection<T>)this).Contains(value);
 }
 
 #endif


### PR DESCRIPTION
Required since `IMySet<T>` implements both a `IMyCollection<T>.Contains` and a `IMyReadOnlySet<T>.Contains`. Before this change the following source code would break as there's no most specific implementation to use.

```c#
IMySet<string> set = GetSet();
set.Contains("Foo");
```